### PR TITLE
Remove empty dividers

### DIFF
--- a/NovaScript.pluto
+++ b/NovaScript.pluto
@@ -187,7 +187,6 @@ if is_installed[7] and is_installed[8] and is_installed[9] and is_installed[10] 
         --------------------OPTIONS--------------------
         -----------------------------------------------
         local root = menu.my_root()
-        root:divider("")
         root:hyperlink(T"Join The Discord Server", "https://discord.gg/E4m6pMUwpx")
         
         local credit_text_positions = {}

--- a/lib/NovaScript/Modules/online.pluto
+++ b/lib/NovaScript/Modules/online.pluto
@@ -669,8 +669,6 @@ smoke_bomb_list:slider(T"Smoke Scale", {"Nsmokescale"}, "", 1, 8, 5, 1, function
 	smoke_scale = count
 end)
 
-online_main:divider("")
-
 ------------------
 --EXPLOSIVE HITS--
 ------------------

--- a/lib/NovaScript/Modules/player_menu.pluto
+++ b/lib/NovaScript/Modules/player_menu.pluto
@@ -809,8 +809,6 @@ weapon_list:action(T"Set Nuke Explosion On Player", {}, "", function()
     func.create_nuke_explosion(position)
 end)
 
-trolling_main:divider("")
-
 --------------------
 --PUT IN GAS TRUCK--
 --------------------
@@ -1248,8 +1246,6 @@ end, function()
         end
     end
 end)
-
-vehicle_main:divider("")
 
 -----------------
 --SPAWN VEHICLE--

--- a/lib/NovaScript/Modules/self.pluto
+++ b/lib/NovaScript/Modules/self.pluto
@@ -1002,8 +1002,6 @@ instant_respawn:toggle_loop(T"Closest Player", {}, "", function()
 	end
 end)
 
-self_main:divider("")
-
 -------------------------
 --WALK & DRIVE ON WATER--
 -------------------------

--- a/lib/NovaScript/Modules/vehicle.pluto
+++ b/lib/NovaScript/Modules/vehicle.pluto
@@ -256,8 +256,6 @@ npcs_list:list_select(T"Driving Style", {}, "", driving_styles_names, 4, functio
     drive_to_closest_player_set.driving_style = driving_styles[index]
 end)
 
-npcs_list:divider("")
-
 ------------------------
 --DRIVE AROUND THE MAP--
 ------------------------
@@ -808,8 +806,6 @@ horn_explosion_list:toggle_loop(T"Horn Explosion", {}, "", function()
         end
     end
 end)
-
-vehicle_main:divider("")
 
 ---------------
 --AUTO REPAIR--

--- a/lib/NovaScript/Modules/weapon.pluto
+++ b/lib/NovaScript/Modules/weapon.pluto
@@ -683,8 +683,6 @@ custom_c4_list:textslider(T"Execute c4", {}, "", custom_c4_explosions, function(
     end
 end)
 
-weapon_main:divider("")
-
 ----------------------
 --ORBITAL STRIKE GUN--
 ----------------------

--- a/lib/NovaScript/Modules/world.pluto
+++ b/lib/NovaScript/Modules/world.pluto
@@ -826,8 +826,6 @@ local firework;firework = firework_list:toggle(T"Firework", {}, "", function(on)
     end
 end)
 
-firework_list:divider("")
-
 --------
 --TYPE--
 --------
@@ -1013,8 +1011,6 @@ end, function()
 	set_train_speed(train, train_max_speed)
 	set_train_cruise_speed(train, train_max_speed)
 end)
-
-world_main:divider("")
 
 -------------------
 --AIM INFORMATION--


### PR DESCRIPTION
One would've been an interesting design choice, but you overdid it. This is a useless waste of space. Also mind that `Stand > Settings > Appearance > Commands > Selectable Dividers` is a thing.